### PR TITLE
Add Pagefind Search Index generator to module

### DIFF
--- a/PAGEFIND_SETUP.md
+++ b/PAGEFIND_SETUP.md
@@ -1,0 +1,314 @@
+# Pagefind Search Setup Guide
+
+## Overview
+
+The `docs-shared` module provides common Pagefind search configuration for TrueNAS documentation sites. This guide explains how to enable search indexing for your Hugo site.
+
+## What's Included in the Module
+
+The `docs-shared` module automatically provides:
+
+1. **Template Modifications** (`layouts/_default/single.html`)
+   - Adds `data-pagefind-body` attribute to mark content for indexing
+   - Adds `data-pagefind-meta` attributes for site identification
+   - No manual template changes needed in your site!
+
+2. **Configuration Template** (`pagefind.template.yml`)
+   - Ready-to-use Pagefind configuration
+   - Pre-configured with common exclusions
+
+## Setup Steps
+
+### 1. Add Search Configuration to Your Site
+
+Add the following to your site's `config.toml`:
+
+```toml
+[params.search]
+  siteName = "Your Site Name"      # Display name in search results
+  siteKey = "your-site-key"        # Unique identifier (lowercase, no spaces)
+  siteIcon = "/path/to/icon.png"   # Icon for search results
+  sitePriority = 1                 # Lower = higher priority in results
+```
+
+**Example for Apps Site:**
+```toml
+[params.search]
+  siteName = "TrueNAS Apps"
+  siteKey = "apps"
+  siteIcon = "/images/TN_Open_Enterprise_Storage_White_Version.png"
+  sitePriority = 2
+```
+
+### 2. Copy Pagefind Configuration
+
+Copy the template configuration to your site root:
+
+```bash
+# From your site directory
+cp path/to/docs-shared/pagefind.template.yml pagefind.yml
+```
+
+Or create `pagefind.yml` in your site root with these contents:
+
+```yaml
+site: public
+output_path: public/pagefind
+
+exclude_selectors:
+  - 'nav'
+  - 'footer'
+  - '.gdoc-nav'
+  - '.gdoc-footer'
+  - '.gdoc-nav--main'
+  - '.gdoc-nav--more'
+  - '.gdoc-page__header'
+  - '.gdoc-page__footer'
+  - '.gdoc-search'
+  - '#search-modal'
+  - '[data-pagefind-ignore]'
+
+keep_index_url: true
+verbose: true
+```
+
+**Site-Specific Adjustments:**
+- **GeekDoc theme sites** (documentation, apps-web, api-docs, security): Use the template as-is
+- **Docsy theme sites** (connect-docs): Add these additional exclusions:
+  ```yaml
+  - '.td-navbar'
+  - '.td-sidebar'
+  - '.td-toc'
+  - '.td-page-meta'
+  ```
+
+### 3. Build Your Site with Search Index
+
+```bash
+# Build Hugo site
+hugo
+
+# Generate search index
+npx pagefind --site public
+```
+
+This creates a `public/pagefind/` directory with:
+- `pagefind.js` - Search engine
+- Index files - Searchable content
+- Fragment files - Search results
+
+### 4. Verify Index Generation
+
+Check that the index was created:
+
+```bash
+ls -la public/pagefind/
+# Should show: pagefind.js, pagefind.en_*.pf_meta, wasm files, etc.
+```
+
+## Integration with Multi-Site Search
+
+If your site participates in the TrueNAS multi-site search (hosted on the Documentation Hub):
+
+1. **Your site provides**: The Pagefind index at `https://yoursite.com/pagefind/`
+2. **Documentation Hub consumes**: Loads and searches your index remotely
+3. **Users search from**: Documentation Hub only (your site doesn't need search UI)
+
+### Requirements for Multi-Site Search
+
+1. ✅ Search configuration in `config.toml` (as shown above)
+2. ✅ Pagefind index generated (`npx pagefind`)
+3. ✅ Index deployed to production at `/pagefind/` path
+4. ✅ CORS enabled (allow Documentation Hub to load your index)
+
+## Build Automation
+
+### Add to Your Build Script
+
+```bash
+#!/bin/bash
+# build.sh
+
+echo "Building Hugo site..."
+hugo
+
+echo "Generating search index..."
+npx pagefind --site public
+
+echo "Build complete!"
+```
+
+### Add to CI/CD Pipeline
+
+**GitHub Actions Example:**
+```yaml
+- name: Build Hugo site
+  run: hugo
+
+- name: Generate search index
+  run: npx pagefind --site public
+```
+
+**Jenkins Example:**
+```groovy
+stage('Build') {
+  steps {
+    sh 'hugo'
+    sh 'npx pagefind --site public'
+  }
+}
+```
+
+## Excluding Content from Search
+
+### Method 1: Page-Level Exclusion
+
+Add to page frontmatter:
+```yaml
+---
+title: "My Page"
+pagefind: false
+---
+```
+
+### Method 2: Element-Level Exclusion
+
+Add `data-pagefind-ignore` attribute:
+```html
+<div data-pagefind-ignore>
+  This content won't be indexed
+</div>
+```
+
+### Method 3: CSS Class
+
+Use the `.no-search` class (defined in pagefind.yml):
+```html
+<div class="no-search">
+  This content won't be indexed
+</div>
+```
+
+## Troubleshooting
+
+### Index Not Generated
+
+**Problem**: `public/pagefind/` directory doesn't exist
+
+**Solutions:**
+1. Check that `hugo` built successfully
+2. Verify `public/` directory exists
+3. Run `npx pagefind --site public --verbose` for detailed output
+4. Check `pagefind.yml` path is correct
+
+### Empty Search Results
+
+**Problem**: Index generated but no results found
+
+**Solutions:**
+1. Verify templates include `data-pagefind-body` (provided by module)
+2. Check that content isn't excluded by `exclude_selectors`
+3. Inspect HTML: `grep "data-pagefind-body" public/**/*.html`
+4. Run with `--verbose` flag to see what's indexed
+
+### Site Metadata Missing
+
+**Problem**: Search results show "Unknown Site"
+
+**Solutions:**
+1. Verify `[params.search]` section in `config.toml`
+2. Check `siteName` and `siteKey` are defined
+3. Rebuild site after config changes
+
+### Cross-Origin Errors (Multi-Site Search)
+
+**Problem**: Documentation Hub can't load your index
+
+**Solutions:**
+1. Ensure index is deployed at `/pagefind/` path
+2. Configure CORS headers to allow Documentation Hub domain
+3. Check browser console for specific CORS errors
+
+## Testing Locally
+
+### Test Single-Site Index
+
+```bash
+# Build and index
+hugo && npx pagefind --site public
+
+# Serve locally
+hugo serve
+
+# Test by searching (if your site has search UI)
+# Or verify files exist: ls public/pagefind/
+```
+
+### Test Multi-Site Integration
+
+See Documentation Hub's `LOCAL_SEARCH_TESTING.md` for instructions on testing multi-site search locally.
+
+## File Size Considerations
+
+Pagefind indexes are typically small:
+- **Small site** (50 pages): ~100-200 KB
+- **Medium site** (500 pages): ~500 KB - 1 MB
+- **Large site** (5000 pages): ~3-5 MB
+
+The index is lazy-loaded, so it doesn't impact initial page load.
+
+## Module Updates
+
+When `docs-shared` module is updated:
+
+```bash
+# Update module
+hugo mod get -u
+
+# Rebuild site
+hugo && npx pagefind --site public
+```
+
+Template changes automatically apply since `single.html` comes from the module.
+
+## Support
+
+- **Pagefind Documentation**: https://pagefind.app/
+- **Module Issues**: https://github.com/truenas/docs-shared/issues
+- **TrueNAS Docs**: Contact documentation team
+
+## Site-Specific Examples
+
+### Documentation Site (GeekDoc)
+```toml
+[params.search]
+  siteName = "TrueNAS Documentation"
+  siteKey = "docs"
+  siteIcon = "/favicon/TN-favicon-32x32.png"
+  sitePriority = 1
+```
+
+### Apps Site (GeekDoc)
+```toml
+[params.search]
+  siteName = "TrueNAS Apps"
+  siteKey = "apps"
+  siteIcon = "/images/TN_Open_Enterprise_Storage_White_Version.png"
+  sitePriority = 2
+```
+
+### Connect Site (Docsy)
+```toml
+[params.search]
+  siteName = "TrueNAS Connect"
+  siteKey = "connect"
+  siteIcon = "/images/tn-openstorage-logo.png"
+  sitePriority = 5
+```
+
+Remember: Each site needs its **own unique `siteKey`**!
+
+---
+
+*Part of the TrueNAS docs-shared Hugo module*
+*Last updated: October 2025*

--- a/README.md
+++ b/README.md
@@ -28,10 +28,56 @@ This section details what shared resources are available in the `docs-shared` mo
 - Shared build and cleanup scripts from apps-web
 - Python scripts for app documentation generation
 
+#### `/docs-shared/pagefind.template.yml`
+- **Pagefind search configuration template** for static site search
+  - Pre-configured exclusions for GeekDoc theme elements
+  - Ready to copy to any site's root directory
+  - Enables participation in multi-site search
+  - See `PAGEFIND_SETUP.md` for complete setup instructions
+
+#### `/docs-shared/PAGEFIND_SETUP.md`
+- **Complete setup guide** for enabling Pagefind search indexing
+  - Step-by-step configuration instructions
+  - Build automation examples (CI/CD, scripts)
+  - Troubleshooting guide
+  - Multi-site search integration notes
+
 #### Other Directories
 - `/docs-shared/assets/` - Empty (reserved for future shared assets)
 - `/docs-shared/data/` - Empty (reserved for future shared data files)
 - `/docs-shared/go.mod` - Hugo module configuration
+
+### Search Index Configuration (Pagefind)
+
+The `docs-shared` module automatically configures your site for Pagefind search indexing. The `layouts/_default/single.html` template includes `data-pagefind-body` and metadata attributes that enable your content to be searchable.
+
+**What's automatic:**
+- ✅ Content pages marked for indexing
+- ✅ Site metadata injection (from `config.toml`)
+- ✅ Template attributes for search engine
+
+**What each site needs to add:**
+
+1. **Add to `config.toml`:**
+```toml
+[params.search]
+  siteName = "Your Site Name"
+  siteKey = "unique-key"
+  siteIcon = "/path/to/icon.png"
+  sitePriority = 1
+```
+
+2. **Copy pagefind config:**
+```bash
+cp docs-shared/pagefind.template.yml pagefind.yml
+```
+
+3. **Build with search:**
+```bash
+hugo && npx pagefind --site public
+```
+
+**See `PAGEFIND_SETUP.md` for complete documentation.**
 
 ## Site-Specific Local Overrides
 

--- a/layouts/_default/baseof.print.html
+++ b/layouts/_default/baseof.print.html
@@ -8,6 +8,7 @@
     <!DOCTYPE html>
     <html lang="{{ .Site.Language.Lang }}" class="no-js">
       <head>
+        <meta name="robots" content="noindex, nofollow">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
         <script>
           $(document).ready(function() {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,6 +5,7 @@
   <article
     class="gdoc-markdown gdoc-markdown__align--{{ default "left" (.Page.Params.GeekdocAlign | lower) }}"
     data-pagefind-body
+    data-pagefind-meta="title:{{ partial "utils/title" . }}"
     {{ with .Site.Params.search.siteKey }}data-pagefind-meta="site:{{ . }}"{{ end }}
     {{ with .Site.Params.search.siteName }}data-pagefind-meta="siteName:{{ . }}"{{ end }}
   >

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,9 @@
 
   <article
     class="gdoc-markdown gdoc-markdown__align--{{ default "left" (.Page.Params.GeekdocAlign | lower) }}"
+    data-pagefind-body
+    {{ with .Site.Params.search.siteKey }}data-pagefind-meta="site:{{ . }}"{{ end }}
+    {{ with .Site.Params.search.siteName }}data-pagefind-meta="siteName:{{ . }}"{{ end }}
   >
     <h1>{{ partial "utils/title" . }}</h1>
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}

--- a/pagefind.template.yml
+++ b/pagefind.template.yml
@@ -1,0 +1,63 @@
+# Pagefind Search Index Configuration Template
+# Copy this file to the root of your Hugo site as: pagefind.yml
+#
+# This template is provided by the docs-shared module for TrueNAS documentation sites.
+# It configures Pagefind to generate a search index for static sites.
+#
+# Usage:
+#   1. Copy this file to your site root: cp pagefind.template.yml ../pagefind.yml
+#   2. Adjust paths and selectors if needed for your site
+#   3. Run: npx pagefind --site public
+#
+# Documentation: https://pagefind.app/docs/config-options/
+
+# Directory containing the built HTML files
+site: public
+
+# Where to output the search index files
+output_path: public/pagefind
+
+# Exclude common non-content elements from indexing
+exclude_selectors:
+  # Navigation elements
+  - 'nav'
+  - '.gdoc-nav'
+  - '.gdoc-nav--main'
+  - '.gdoc-nav--more'
+  - '.gdoc-nav--tags'
+
+  # Footer elements
+  - 'footer'
+  - '.gdoc-footer'
+  - '.gdoc-page__footer'
+
+  # Header elements
+  - 'header'
+  - '.gdoc-page__header'
+
+  # Search elements (avoid indexing the search UI itself)
+  - '.gdoc-search'
+  - '#search-modal'
+  - '.search-modal'
+
+  # Other common elements to exclude
+  - '[data-pagefind-ignore]'  # Manually marked elements
+  - '.no-search'              # Custom class for excluded content
+
+# Keep the full URL in search results (important for cross-site search)
+keep_index_url: true
+
+# Enable verbose output during index generation (helpful for debugging)
+verbose: true
+
+# Force language detection (optional - adjust if your site uses a different language)
+# force_language: "en"
+
+# ============================================================================
+# Site-Specific Exclusions
+# ============================================================================
+# Add any additional selectors specific to your site below.
+# Examples:
+#   - '.site-specific-class'
+#   - '#sidebar'
+#   - '.advertisement'


### PR DESCRIPTION
This is an experimental change to add initial multi-site support and filtering to static search on the Docs Hub.
Also adjusts the printview generator to add noindex meta to these urls. This avoids lots of duplicate search results for lower quality printview options.