### PR TITLE
DOCS-2707: Replace UserCentrics with CookieYes cookie banner

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,5 +1,6 @@
-<!-- Usercentrics Cookie Consent Management -->
-<script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-ruleset-id="44bxGXioqiqorL" async></script>
+<!-- Start cookieyes banner -->
+<script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/c005e666a046ac87072fe64f27dbdc4e/script.js"></script>
+<!-- End cookieyes banner -->
 
 <!-- Favicons -->
 <link rel="icon" type="image/svg+xml" href="/favicons/favicon.svg">


### PR DESCRIPTION
## Summary
- Replaces the UserCentrics cookie-consent script with the new CookieYes snippet in `layouts/partials/hooks/head-end.html`, on the TrueShared2026 (Docsy-cutover) branch.
- `docs/`'s go.mod pin currently resolves to a commit on this branch's history, so `docs/` inherits this change once its own go.mod is bumped to a commit at or after this merge — that follow-up is tracked separately and is intentionally not part of this PR.

## Test plan
- [x] Confirmed via `git show` that the old/new snippet swap is byte-exact and touches only the intended 2 lines.
- [ ] Confirm `docs/`'s go.mod bump (follow-up) picks up this change and the banner renders live.